### PR TITLE
Fix WRITES count when NOT using network

### DIFF
--- a/output_write.c
+++ b/output_write.c
@@ -101,15 +101,19 @@ void ts_frame_process(CONFIG *conf, OUTPUT *o, uint8_t *data) {
 }
 
 ssize_t ts_frame_write(OUTPUT *o, uint8_t *data) {
-	ssize_t written;
+	ssize_t written, written2;
+
 	written = fdwrite(o->out_sock, (char *)data, FRAME_PACKET_SIZE);
+	if (o->ofd)
+		written2 = write(o->ofd, data, FRAME_PACKET_SIZE);
+	else written2 = 0;
+
+	if (written2 > written)
+		written = written2;
 	if (written >= 0) {
 		o->traffic        += written;
 		o->traffic_period += written;
 	}
-
-	if (o->ofd)
-		write(o->ofd, data, FRAME_PACKET_SIZE);
 
 	return written;
 }


### PR DESCRIPTION
Without this patch when the Network output is disabled, nothing is counted as writen in the output file. Then the program raises this error: `host ux-mptsd: OUTPUT: Error writing into output socket.`